### PR TITLE
Look for ndbm.h in /usr/local/include too

### DIFF
--- a/configure
+++ b/configure
@@ -42,7 +42,7 @@ dbm_include="not found"
 dbm_link="not found"
 dbm_defines=""
 
-for dir in /usr/include /usr/include/db1 /usr/include/gdbm; do
+for dir in /usr/include /usr/include/db1 /usr/include/gdbm /usr/local/include; do
   if test -f $dir/ndbm.h; then
     dbm_include=$dir
     if hasgot $dir ndbm.h; then


### PR DESCRIPTION
In macOS 10.12.4
% brew install gdbm --with-libgdbm-compat

puts ndbm.h in /usr/local/include.