### PR TITLE
Port to Dune/Jbuilder

### DIFF
--- a/.depend
+++ b/.depend
@@ -1,3 +1,0 @@
-dbm.cmo: dbm.cmi
-dbm.cmx: dbm.cmi
-dbm.cmi:

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Default behaviour, for if core.autocrlf isn't set
+* text=auto
+
+configure text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+Makefile.config
+
 testdbm.byte
 testdbm.opt
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+testdbm.byte
+testdbm.opt
+
+# general patterns
+
+*.o
+*.a
+*.so
+*.obj
+*.lib
+*.dll
+*.cm[ioxat]
+*.cmx[as]
+*.cmti
+*.annot
+*.exe
+*.sw[po]

--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,9 @@
-Makefile.config
-
-testdbm.byte
-testdbm.opt
+_build
+.merlin
+dbm.install
+c-flags.sexp
+c-library-flags.sexp
 
 # general patterns
 
-*.o
-*.a
-*.so
-*.obj
-*.lib
-*.dll
-*.cm[ioxat]
-*.cmx[as]
-*.cmti
-*.annot
-*.exe
 *.sw[po]

--- a/META
+++ b/META
@@ -1,5 +1,0 @@
-description = "Access to GDBM/NDBM databases"
-requires = ""
-version = "1.0"
-archive(byte) = "dbm.cma"
-archive(native) = "dbm.cmxa"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #                                                                       #
 #########################################################################
 
-include Makefile.config
+-include Makefile.config
 
 OCAMLC=ocamlc
 OCAMLOPT=ocamlopt
@@ -66,7 +66,7 @@ install::
 	if test -f dbm.cmxs; then cp dbm.cmxs $(LIBDIR)/; fi
 
 clean::
-	rm -f *.cm* *.$(O) *.$(A) *.$(SO)
+	rm -f *.cm* *.$(O) *.$(A) *.$(SO) Makefile.config
 
 testdbm.byte: dbm.cma testdbm.ml
 	$(OCAMLC) -o $@ dbm.cma testdbm.ml

--- a/Makefile
+++ b/Makefile
@@ -11,78 +11,31 @@
 #                                                                       #
 #########################################################################
 
--include Makefile.config
+JBUILDER?=jbuilder
+RM?=rm
 
-OCAMLC=ocamlc
-OCAMLOPT=ocamlopt
-OCAMLMKLIB=ocamlmklib
-OCAMLDEP=ocamldep
-OCAMLRUN=ocamlrun
-O=o
-A=a
-SO=so
+# Legacy items kept to allow installation
 LIBDIR=`ocamlc -where`
 STUBLIBDIR=$(LIBDIR)/stublibs
+A=`ocamlc -config | sed -ne 's/ext_lib: //p'`
+SO=`ocamlc -config | sed -ne 's/ext_dll: //p'`
+ROOT=_build/install/default
 
+all:
+	$(JBUILDER) build @install
 
-all: libcamldbm.$(A) dbm.cma dbm.cmxa dbm.cmxs 
+install:
+	if test -f $(ROOT)/lib/stublibs/dlldbm_stubs$(SO); then mkdir $(STUBLIBDIR) || echo Ok; cp $(ROOT)/lib/stublibs/dlldbm_stubs$(SO) $(STUBLIBDIR)/; fi
+	cp $(ROOT)/lib/dbm/libdbm_stubs$(A) $(LIBDIR)/
+#	cd $(LIBDIR) && ranlib libdbm_stubs$(A)
+	cp $(ROOT)/lib/dbm/dbm.cma $(ROOT)/lib/dbm/dbm.cmxa $(ROOT)/lib/dbm/dbm.cmi $(ROOT)/lib/dbm/dbm.mli $(LIBDIR)/
+	cp $(ROOT)/lib/dbm/dbm$(A) $(LIBDIR)/
+#	cd $(LIBDIR) && ranlib dbm$(A)
+	if test -f $(ROOT)/lib/dbm/dbm.cmxs; then cp $(ROOT)/lib/dbm/dbm.cmxs $(LIBDIR)/; fi
 
-dbm.cma: dbm.cmo
-	$(OCAMLMKLIB) -o dbm -oc camldbm -linkall dbm.cmo $(DBM_LINK)
+clean:
+	$(RM) -f *.sexp
+	$(JBUILDER) clean
 
-dbm.cmxa: dbm.cmx
-	$(OCAMLMKLIB) -o dbm -oc camldbm -linkall dbm.cmx $(DBM_LINK)
-
-dbm.cmxs: dbm.cmxa libcamldbm.$(A)
-	$(OCAMLOPT) -shared -o dbm.cmxs -I . dbm.cmxa
-
-libcamldbm.$(A): cldbm.$(O)
-	$(OCAMLMKLIB) -oc camldbm cldbm.$(O) $(DBM_LINK)
-
-.SUFFIXES: .ml .mli .cmi .cmo .cmx .$(O)
-
-.mli.cmi:
-	$(OCAMLC) -c $(COMPFLAGS) $<
-
-.ml.cmo:
-	$(OCAMLC) -c $(COMPFLAGS) $<
-
-.ml.cmx:
-	$(OCAMLOPT) -c $(COMPFLAGS) $<
-
-.c.$(O):
-	$(OCAMLC) -c -ccopt "$(DBM_INCLUDES)" -ccopt "$(DBM_DEFINES)" $<
-
-depend:
-	$(OCAMLDEP) *.ml *.mli > .depend
-
-install::
-	if test -f dllcamldbm.$(SO); then mkdir $(STUBLIBDIR) || echo Ok; cp dllcamldbm.$(SO) $(STUBLIBDIR)/; fi 
-	cp libcamldbm.$(A) $(LIBDIR)/
-	cd $(LIBDIR) && ranlib libcamldbm.$(A)
-	cp dbm.cma dbm.cmxa dbm.cmi dbm.mli $(LIBDIR)/
-	cp dbm.$(A) $(LIBDIR)/
-	cd $(LIBDIR) && ranlib dbm.$(A)
-	if test -f dbm.cmxs; then cp dbm.cmxs $(LIBDIR)/; fi
-
-clean::
-	rm -f *.cm* *.$(O) *.$(A) *.$(SO) Makefile.config
-
-testdbm.byte: dbm.cma testdbm.ml
-	$(OCAMLC) -o $@ dbm.cma testdbm.ml
-
-testdbm.opt: dbm.cmxa testdbm.ml
-	$(OCAMLOPT) -ccopt -L. -o $@ dbm.cmxa testdbm.ml
-
-clean::
-	rm -f testdbm.byte testdbm.opt testdatabase.*
-
-test: testdbm.byte testdbm.opt
-	rm -f testdatabase.*
-	ocamlrun -I . ./testdbm.byte
-	rm -f testdatabase.*
-	./testdbm.opt
-	rm -f testdatabase.*
-	
-
-include .depend
+test:
+	$(JBUILDER) runtest --force

--- a/Makefile.config
+++ b/Makefile.config
@@ -1,4 +1,0 @@
-OCAML_STDLIB=/home/xleroy/.opam/4.03.0/lib/ocaml
-DBM_INCLUDES=
-DBM_LINK=-lgdbm_compat -lgdbm
-DBM_DEFINES=-DDBM_USES_GDBM_NDBM

--- a/configure
+++ b/configure
@@ -20,10 +20,16 @@ if test $? -ne 0; then
   exit 2
 fi
 
-echo "Configuring for OCaml version $version"
-echo
+if [ "$1" = "--quiet" ] ; then
+  QUIET=1
+else
+  QUIET=0
+fi
 
-stdlib=`ocamlc -where`
+if [ $QUIET -eq 0 ] ; then
+  echo "Configuring for OCaml version $version"
+  echo
+fi
 
 # This slightly strange looking command will prefer c_compiler for versions
 # of OCaml which have it, but will fallback to bytecode_c_compiler otherwise
@@ -88,13 +94,15 @@ if test "$dbm_include" = "not found" || test "$dbm_link" = "not found"; then
   exit 2
 fi
 
-echo "Configuration for the \"camldbm\" library:"
-echo "        headers found in ......... $dbm_include"
-echo "        options for compiling .... $dbm_defines"
-echo "        options for linking ...... $dbm_link"
-echo
-echo "Configuration successful"
-echo
+if [ $QUIET -eq 0 ] ; then
+  echo "Configuration for the \"camldbm\" library:"
+  echo "        headers found in ......... $dbm_include"
+  echo "        options for compiling .... $dbm_defines"
+  echo "        options for linking ...... $dbm_link"
+  echo
+  echo "Configuration successful"
+  echo
+fi
 
 if test "$dbm_include" = "/usr/include"; then
   dbm_include=""
@@ -102,8 +110,6 @@ else
   dbm_include="-I$dbm_include"
 fi
 
-echo "OCAML_STDLIB=$stdlib" > Makefile.config
-echo "DBM_INCLUDES=$dbm_include" >> Makefile.config
-echo "DBM_LINK=$dbm_link" >> Makefile.config
-echo "DBM_DEFINES=$dbm_defines" >> Makefile.config
+echo "($dbm_include $dbm_defines)" > c-flags.sexp
+echo "($dbm_link)" > c-library-flags.sexp
 

--- a/configure
+++ b/configure
@@ -50,7 +50,7 @@ dbm_include="not found"
 dbm_link="not found"
 dbm_defines=""
 
-for dir in /usr/include /usr/include/db1 /usr/include/gdbm /usr/local/include; do
+for dir in `$CC -xc -E -v /dev/null 2>&1 | sed -e '1,/#include <...>/d' -e '/End of search list./,$d'` /usr/include /usr/include/db1 /usr/include/gdbm /usr/local/include ; do
   if test -f $dir/ndbm.h; then
     dbm_include=$dir
     dbm_defines="-DDBM_COMPAT"

--- a/configure
+++ b/configure
@@ -25,6 +25,10 @@ echo
 
 stdlib=`ocamlc -where`
 
+# This slightly strange looking command will prefer c_compiler for versions
+# of OCaml which have it, but will fallback to bytecode_c_compiler otherwise
+CC=${CC:-`ocamlc -config | tr -d '\r' | sed -ne 's/.*c_compiler: //p' | head -n 1`}
+
 hasgot() {
   rm -f hasgot.c
   (echo "#include <$2>"
@@ -36,7 +40,7 @@ hasgot() {
    fi
    echo '  return 0;'
    echo '}') > hasgot.c
-  ${CC:-cc} -I$1 -o hasgot.exe hasgot.c $3 $4
+  $CC -I$1 -o hasgot.exe hasgot.c $3 $4 2>/dev/null
   res=$?
   rm -f hasgot.c hasgot.exe
   return $res

--- a/dbm.opam
+++ b/dbm.opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Francois Rouaix"]
+homepage: "https://github.com/ocaml/dbm"
+bug-reports: "https://github.com/ocaml/dbm/issues"
+dev-repo: "https://github.com/ocaml/dbm.git"
+license: "LGPL-v2 with OCaml linking exception"
+build: [
+  ["mkdir" "-p" "%{lib}%/dbm"]
+  ["./configure"]
+  [make "all"]
+  [make "test"]
+]
+depends: ["ocamlfind"]
+depexts: [
+  [["debian"] ["libgdbm-dev"]]
+  [["ubuntu"] ["libgdbm-dev"]]
+  [["nixpkgs"] ["gdbm"]]
+  [["centos"] ["gdbm-devel"]]
+  [["rhel"] ["gdbm-devel"]]
+  [["fedora"] ["gdbm-devel"]]
+  [["alpine"] ["gdbm-dev"]]
+  [["osx" "homebrew"] ["gdbm"]]
+  [["archlinux"] ["gdbm"]]
+]
+install: [
+  [make "install" "STUBLIBDIR=%{lib}%/stublibs" "LIBDIR=%{lib}%/dbm"]
+  ["cp" "META" "%{lib}%/dbm"]
+]
+remove: [
+  ["rm" "-f" "%{lib}%/stublibs/dllcamldbm.so"]
+  ["ocamlfind" "remove" "dbm"]
+]

--- a/dbm.opam
+++ b/dbm.opam
@@ -1,4 +1,5 @@
 opam-version: "1.2"
+version: "1.2"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Francois Rouaix"]
 homepage: "https://github.com/ocaml/dbm"
@@ -6,12 +7,10 @@ bug-reports: "https://github.com/ocaml/dbm/issues"
 dev-repo: "https://github.com/ocaml/dbm.git"
 license: "LGPL-v2 with OCaml linking exception"
 build: [
-  ["mkdir" "-p" "%{lib}%/dbm"]
-  ["./configure"]
   [make "all"]
   [make "test"]
 ]
-depends: ["ocamlfind"]
+depends: ["jbuilder" {build & >= "1.0+beta17"}]
 depexts: [
   [["debian"] ["libgdbm-dev"]]
   [["ubuntu"] ["libgdbm-dev"]]
@@ -22,12 +21,4 @@ depexts: [
   [["alpine"] ["gdbm-dev"]]
   [["osx" "homebrew"] ["gdbm"]]
   [["archlinux"] ["gdbm"]]
-]
-install: [
-  [make "install" "STUBLIBDIR=%{lib}%/stublibs" "LIBDIR=%{lib}%/dbm"]
-  ["cp" "META" "%{lib}%/dbm"]
-]
-remove: [
-  ["rm" "-f" "%{lib}%/stublibs/dllcamldbm.so"]
-  ["ocamlfind" "remove" "dbm"]
 ]

--- a/jbuild
+++ b/jbuild
@@ -1,0 +1,27 @@
+(jbuild_version 1)
+
+(library
+  ((name            dbm)
+   (public_name     dbm)
+   (synopsis        "Access to GDBM/NDBM databases")
+   (modules         (dbm))
+   (c_names         (cldbm))
+   (c_flags         (:include c-flags.sexp))
+   (c_library_flags (:include c-library-flags.sexp))
+   (wrapped         false)))
+
+(rule
+  ((targets (c-flags.sexp c-library-flags.sexp))
+   (deps    (configure))
+   (mode    fallback)
+   (action  (run "sh" "-c" "./configure --quiet"))))
+
+(executable
+  ((name      testdbm)
+   (modules   testdbm)
+   (libraries (dbm))))
+
+(alias
+  ((name   runtest)
+   (deps   (testdbm.exe))
+   (action (run ${<}))))


### PR DESCRIPTION
Hey, it's Friday - why have one port when you can have two? This is presently based on #9. Only the last two commits are new.

The addition of the opam file should be non-controversial - it's just the one from opam-repository with the addition of a `version` field. This version gets picked up by `jbuilder` and transferred to the generated META file. In general, once released, it's worth bumping the version in `dbm.opam` (just like we do with `VERSION` in OCaml) as that means if you pin the package in opam, it looks like a newer version at once.

This port differs from #8 in a few ways:
 - `configure` is called by `jbuild` rules. Importantly, `configure` can also be called manually which will take precedent (this is done using Dune's `fallback` mode for generated files).
 - The original `Makefile` is preserved - I certainly prefer typing `make`, even in a Dune project. The old targets are maintained. I have ported over the old `install` target for completeness - though obviously installation using `opam-installer` (or `jbuilder install`) would be preferred.

The only future work which would want doing here would be to eliminate the `configure` script and convert it to Configurator, but this is best left until the imminent release of Dune 1.0.0.

I haven't tried this on MSVC, because there are limits even to my ability to distract myself from what I should be doing. I would anticipate it would work as long as the `c-flags.sexp` and `c-library-flags.sexp` are generated by hand with the correct flags to point cl at the header and import library.