### PR TITLE
Fix memory leak in caml_dbm_fetch

### DIFF
--- a/cldbm.c
+++ b/cldbm.c
@@ -127,7 +127,12 @@ value caml_dbm_fetch(value vdb, value vkey)  /* ML */
 #else
   answer = gdbm_fetch(extract_dbm(vdb), key);
 #endif
-  if (answer.dptr) return alloc_datum(&answer); else caml_raise_not_found();
+  if (answer.dptr) {
+    value res = alloc_datum(&answer);
+    free(answer.dptr);
+    return res;
+  }
+  else caml_raise_not_found();
 }
 
 value caml_dbm_insert(value vdb, value vkey, value vcontent) /* ML */

--- a/cldbm.c
+++ b/cldbm.c
@@ -129,7 +129,9 @@ value caml_dbm_fetch(value vdb, value vkey)  /* ML */
 #endif
   if (answer.dptr) {
     value res = alloc_datum(&answer);
+#ifndef DBM_COMPAT
     free(answer.dptr);
+#endif
     return res;
   }
   else caml_raise_not_found();


### PR DESCRIPTION
While hunting a memory leak in a program of mine, I noticed this piece of code in `cldbm.c`:
```c
value caml_dbm_fetch(value vdb, value vkey)  /* ML */
{
  datum key, answer;
  extract_datum(vkey, &key);
#ifdef DBM_COMPAT
  answer = dbm_fetch(extract_dbm(vdb), key);
#else
  answer = gdbm_fetch(extract_dbm(vdb), key);
#endif
  if (answer.dptr) return alloc_datum(&answer); else caml_raise_not_found();
}
```
in which the memory allocated to `answer` is not freed, although as said in the [documentation](https://www.gnu.org.ua/software/gdbm/manual/Fetch.html):

>gdbm interface: datum gdbm_fetch (GDBM_FILE dbf, datum key)
>
>    Looks up a given key and returns the information associated with it. The dptr field in the structure that is returned points to a memory block allocated by malloc. **It is the caller’s responsibility to free it when no longer needed.**

(it's not done in `alloc_datum` either). Here's a simple change, which fixes the memory leak I was after.